### PR TITLE
fix: Fixes severity to use Moderate instead of Medium

### DIFF
--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -206,7 +206,7 @@ func renderSeveritySummary() {
 	t.AppendHeader(table.Row{"Rating", "Count"})
 	t.AppendRow([]interface{}{"CRITICAL", severitySummary.Critical})
 	t.AppendRow([]interface{}{"HIGH", severitySummary.High})
-	t.AppendRow([]interface{}{"MEDIUM", severitySummary.Medium})
+	t.AppendRow([]interface{}{"MODERATE", severitySummary.Moderate})
 	t.AppendRow([]interface{}{"LOW", severitySummary.Low})
 	if severitySummary.None > 0 {
 		t.AppendRow([]interface{}{"NONE", severitySummary.None})
@@ -222,7 +222,7 @@ func ratingScale(score float64) string {
 	if score > 0 && score <= 3.9 {
 		return "LOW"
 	} else if score >= 4.0 && score <= 6.9 {
-		return "MEDIUM"
+		return "MODERATE"
 	} else if score >= 7.0 && score <= 8.9 {
 		return "HIGH"
 	} else if score >= 9.0 && score <= 10.0 {
@@ -234,9 +234,9 @@ func ratingScale(score float64) string {
 func adjustSummary(severity string) {
 	switch severity {
 	case "LOW":
-		severitySummary.Low = severitySummary.Low + 1
-	case "MEDIUM":
-		severitySummary.Medium++
+		severitySummary.Low++
+	case "MODERATE":
+		severitySummary.Moderate++
 	case "HIGH":
 		severitySummary.High++
 	case "CRITICAL":

--- a/models/structs.go
+++ b/models/structs.go
@@ -23,7 +23,7 @@ type Vulnerability struct {
 type SeveritySummary struct {
 	None     int
 	Low      int
-	Medium   int
+	Moderate int
 	High     int
 	Critical int
 }

--- a/sbom/bomber.cyclonedx.json
+++ b/sbom/bomber.cyclonedx.json
@@ -1,10 +1,10 @@
 {
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
-  "serialNumber": "urn:uuid:adf90662-c555-4b39-b892-794927ab3506",
+  "serialNumber": "urn:uuid:36a1e3f0-29d7-4a86-90a6-5c7f2a05bcc6",
   "version": 1,
   "metadata": {
-    "timestamp": "2022-08-30T12:12:34-06:00",
+    "timestamp": "2022-08-30T12:56:39-06:00",
     "tools": [
       {
         "vendor": "anchore",
@@ -202,12 +202,12 @@
       ]
     },
     {
-      "bom-ref": "pkg:golang/github.com/devops-kung-fu/bomber@v0.0.0-20220830173600-697ad6dae951?package-id=673dd272d675f76d",
+      "bom-ref": "pkg:golang/github.com/devops-kung-fu/bomber@v0.0.0-20220830181417-92636f920a69?package-id=58cc7600bb924944",
       "type": "library",
       "name": "github.com/devops-kung-fu/bomber",
-      "version": "v0.0.0-20220830173600-697ad6dae951",
-      "cpe": "cpe:2.3:a:devops-kung-fu:bomber:v0.0.0-20220830173600-697ad6dae951:*:*:*:*:*:*:*",
-      "purl": "pkg:golang/github.com/devops-kung-fu/bomber@v0.0.0-20220830173600-697ad6dae951",
+      "version": "v0.0.0-20220830181417-92636f920a69",
+      "cpe": "cpe:2.3:a:devops-kung-fu:bomber:v0.0.0-20220830181417-92636f920a69:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/devops-kung-fu/bomber@v0.0.0-20220830181417-92636f920a69",
       "properties": [
         {
           "name": "syft:package:foundBy",
@@ -227,19 +227,19 @@
         },
         {
           "name": "syft:cpe23",
-          "value": "cpe:2.3:a:devops_kung_fu:bomber:v0.0.0-20220830173600-697ad6dae951:*:*:*:*:*:*:*"
+          "value": "cpe:2.3:a:devops_kung_fu:bomber:v0.0.0-20220830181417-92636f920a69:*:*:*:*:*:*:*"
         },
         {
           "name": "syft:cpe23",
-          "value": "cpe:2.3:a:devops-kung:bomber:v0.0.0-20220830173600-697ad6dae951:*:*:*:*:*:*:*"
+          "value": "cpe:2.3:a:devops-kung:bomber:v0.0.0-20220830181417-92636f920a69:*:*:*:*:*:*:*"
         },
         {
           "name": "syft:cpe23",
-          "value": "cpe:2.3:a:devops_kung:bomber:v0.0.0-20220830173600-697ad6dae951:*:*:*:*:*:*:*"
+          "value": "cpe:2.3:a:devops_kung:bomber:v0.0.0-20220830181417-92636f920a69:*:*:*:*:*:*:*"
         },
         {
           "name": "syft:cpe23",
-          "value": "cpe:2.3:a:devops:bomber:v0.0.0-20220830173600-697ad6dae951:*:*:*:*:*:*:*"
+          "value": "cpe:2.3:a:devops:bomber:v0.0.0-20220830181417-92636f920a69:*:*:*:*:*:*:*"
         },
         {
           "name": "syft:location:0:path",

--- a/sbom/bomber.spdx.json
+++ b/sbom/bomber.spdx.json
@@ -3,7 +3,7 @@
  "name": ".",
  "spdxVersion": "SPDX-2.2",
  "creationInfo": {
-  "created": "2022-08-30T18:12:34.580348Z",
+  "created": "2022-08-30T18:56:39.550112Z",
   "creators": [
    "Organization: Anchore, Inc",
    "Tool: syft-[not provided]"
@@ -11,7 +11,7 @@
   "licenseListVersion": "3.18"
  },
  "dataLicense": "CC0-1.0",
- "documentNamespace": "https://anchore.com/syft/dir/9ba284cb-1d4d-4a91-8504-c524f7e759b5",
+ "documentNamespace": "https://anchore.com/syft/dir/3d6bf186-86c2-401f-9e1c-b4ed5e9e822c",
  "packages": [
   {
    "SPDXID": "SPDXRef-135cc8bc545c374",
@@ -139,46 +139,46 @@
    "versionInfo": "v1.1.1"
   },
   {
-   "SPDXID": "SPDXRef-673dd272d675f76d",
+   "SPDXID": "SPDXRef-58cc7600bb924944",
    "name": "github.com/devops-kung-fu/bomber",
    "licenseConcluded": "NONE",
    "downloadLocation": "NOASSERTION",
    "externalRefs": [
     {
      "referenceCategory": "SECURITY",
-     "referenceLocator": "cpe:2.3:a:devops-kung-fu:bomber:v0.0.0-20220830173600-697ad6dae951:*:*:*:*:*:*:*",
+     "referenceLocator": "cpe:2.3:a:devops-kung-fu:bomber:v0.0.0-20220830181417-92636f920a69:*:*:*:*:*:*:*",
      "referenceType": "cpe23Type"
     },
     {
      "referenceCategory": "SECURITY",
-     "referenceLocator": "cpe:2.3:a:devops_kung_fu:bomber:v0.0.0-20220830173600-697ad6dae951:*:*:*:*:*:*:*",
+     "referenceLocator": "cpe:2.3:a:devops_kung_fu:bomber:v0.0.0-20220830181417-92636f920a69:*:*:*:*:*:*:*",
      "referenceType": "cpe23Type"
     },
     {
      "referenceCategory": "SECURITY",
-     "referenceLocator": "cpe:2.3:a:devops-kung:bomber:v0.0.0-20220830173600-697ad6dae951:*:*:*:*:*:*:*",
+     "referenceLocator": "cpe:2.3:a:devops-kung:bomber:v0.0.0-20220830181417-92636f920a69:*:*:*:*:*:*:*",
      "referenceType": "cpe23Type"
     },
     {
      "referenceCategory": "SECURITY",
-     "referenceLocator": "cpe:2.3:a:devops_kung:bomber:v0.0.0-20220830173600-697ad6dae951:*:*:*:*:*:*:*",
+     "referenceLocator": "cpe:2.3:a:devops_kung:bomber:v0.0.0-20220830181417-92636f920a69:*:*:*:*:*:*:*",
      "referenceType": "cpe23Type"
     },
     {
      "referenceCategory": "SECURITY",
-     "referenceLocator": "cpe:2.3:a:devops:bomber:v0.0.0-20220830173600-697ad6dae951:*:*:*:*:*:*:*",
+     "referenceLocator": "cpe:2.3:a:devops:bomber:v0.0.0-20220830181417-92636f920a69:*:*:*:*:*:*:*",
      "referenceType": "cpe23Type"
     },
     {
      "referenceCategory": "PACKAGE_MANAGER",
-     "referenceLocator": "pkg:golang/github.com/devops-kung-fu/bomber@v0.0.0-20220830173600-697ad6dae951",
+     "referenceLocator": "pkg:golang/github.com/devops-kung-fu/bomber@v0.0.0-20220830181417-92636f920a69",
      "referenceType": "purl"
     }
    ],
    "filesAnalyzed": false,
    "licenseDeclared": "NONE",
    "sourceInfo": "acquired package info from go module information: bomber",
-   "versionInfo": "v0.0.0-20220830173600-697ad6dae951"
+   "versionInfo": "v0.0.0-20220830181417-92636f920a69"
   },
   {
    "SPDXID": "SPDXRef-b752bd20a7f80e7c",

--- a/sbom/bomber.syft.json
+++ b/sbom/bomber.syft.json
@@ -108,9 +108,9 @@
    "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
   },
   {
-   "id": "673dd272d675f76d",
+   "id": "58cc7600bb924944",
    "name": "github.com/devops-kung-fu/bomber",
-   "version": "v0.0.0-20220830173600-697ad6dae951",
+   "version": "v0.0.0-20220830181417-92636f920a69",
    "type": "go-module",
    "foundBy": "go-module-binary-cataloger",
    "locations": [
@@ -121,13 +121,13 @@
    "licenses": [],
    "language": "go",
    "cpes": [
-    "cpe:2.3:a:devops-kung-fu:bomber:v0.0.0-20220830173600-697ad6dae951:*:*:*:*:*:*:*",
-    "cpe:2.3:a:devops_kung_fu:bomber:v0.0.0-20220830173600-697ad6dae951:*:*:*:*:*:*:*",
-    "cpe:2.3:a:devops-kung:bomber:v0.0.0-20220830173600-697ad6dae951:*:*:*:*:*:*:*",
-    "cpe:2.3:a:devops_kung:bomber:v0.0.0-20220830173600-697ad6dae951:*:*:*:*:*:*:*",
-    "cpe:2.3:a:devops:bomber:v0.0.0-20220830173600-697ad6dae951:*:*:*:*:*:*:*"
+    "cpe:2.3:a:devops-kung-fu:bomber:v0.0.0-20220830181417-92636f920a69:*:*:*:*:*:*:*",
+    "cpe:2.3:a:devops_kung_fu:bomber:v0.0.0-20220830181417-92636f920a69:*:*:*:*:*:*:*",
+    "cpe:2.3:a:devops-kung:bomber:v0.0.0-20220830181417-92636f920a69:*:*:*:*:*:*:*",
+    "cpe:2.3:a:devops_kung:bomber:v0.0.0-20220830181417-92636f920a69:*:*:*:*:*:*:*",
+    "cpe:2.3:a:devops:bomber:v0.0.0-20220830181417-92636f920a69:*:*:*:*:*:*:*"
    ],
-   "purl": "pkg:golang/github.com/devops-kung-fu/bomber@v0.0.0-20220830173600-697ad6dae951",
+   "purl": "pkg:golang/github.com/devops-kung-fu/bomber@v0.0.0-20220830181417-92636f920a69",
    "metadataType": "GolangBinMetadata",
    "metadata": {
     "goBuildSettings": {
@@ -142,8 +142,8 @@
      "GOOS": "darwin",
      "vcs": "git",
      "vcs.modified": "true",
-     "vcs.revision": "697ad6dae951825b777564c174f3dc020cae6f24",
-     "vcs.time": "2022-08-30T17:36:00Z"
+     "vcs.revision": "92636f920a69e8482d8be1192968e886560f71ce",
+     "vcs.time": "2022-08-30T18:14:17Z"
     },
     "goCompiledVersion": "go1.19",
     "architecture": "amd64",


### PR DESCRIPTION
Severity counts are displaying incorrectly because of a string mismatch with medium and moderate severity strings.