### PR TITLE
feat: add Snyk provider

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,10 +11,11 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.4.0
 	github.com/kirinlabs/HttpRequest v1.1.1
 	github.com/package-url/packageurl-go v0.1.0
+	github.com/remeh/sizedwaitgroup v1.0.0
 	github.com/spf13/afero v1.9.2
-	github.com/spf13/cobra v1.5.0
+	github.com/spf13/cobra v1.6.0
 	github.com/stretchr/testify v1.8.0
-	k8s.io/utils v0.0.0-20220922133306-665eaaec4324
+	k8s.io/utils v0.0.0-20221012122500-cfd413dd9e85
 )
 
 require (
@@ -30,8 +31,8 @@ require (
 	github.com/rivo/uniseg v0.4.2 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec // indirect
-	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/sys v0.1.0 // indirect
+	golang.org/x/text v0.4.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -130,7 +130,6 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jarcoal/httpmock v1.2.0 h1:gSvTxxFR/MEMfsGrvRbdfpRUMBStovlSRLw0Ep1bwwc=
@@ -171,6 +170,8 @@ github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qR
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/remeh/sizedwaitgroup v1.0.0 h1:VNGGFwNo/R5+MJBf6yrsr110p0m4/OX4S3DCy7Kyl5E=
+github.com/remeh/sizedwaitgroup v1.0.0/go.mod h1:3j2R4OIe/SeS6YDhICBy22RWjJC5eNCJ1V+9+NVNYlo=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.2 h1:YwD0ulJSJytLpiaWua0sBDusfsCZohxjxzVTYjwxfV8=
 github.com/rivo/uniseg v0.4.2/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
@@ -178,8 +179,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/afero v1.9.2 h1:j49Hj62F0n+DaZ1dDCvhABaPNSGNkt32oRFxI33IEMw=
 github.com/spf13/afero v1.9.2/go.mod h1:iUV7ddyEEZPO5gA3zD4fJt6iStLlL+Lg4m2cihcDf8Y=
-github.com/spf13/cobra v1.5.0 h1:X+jTBEBqF0bHN+9cSMgmfuvv2VHJ9ezmFNf9Y/XstYU=
-github.com/spf13/cobra v1.5.0/go.mod h1:dWXEIy2H428czQCjInthrTRUg7yKbok+2Qi/yBIJoUM=
+github.com/spf13/cobra v1.6.0 h1:42a0n6jwCot1pUmomAp4T7DeMD+20LFv4Q54pxLf2LI=
+github.com/spf13/cobra v1.6.0/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -334,8 +335,8 @@ golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec h1:BkDtF2Ih9xZ7le9ndzTA7KJow28VbQW3odyk/8drmuI=
-golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -343,8 +344,8 @@ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
-golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/text v0.4.0 h1:BrVqGRd7+k1DiOgtnFvAkoQEWQvBc25ouMJM6429SFg=
+golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -493,7 +494,6 @@ gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8X
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
@@ -504,8 +504,8 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-k8s.io/utils v0.0.0-20220922133306-665eaaec4324 h1:i+xdFemcSNuJvIfBlaYuXgRondKxK4z4prVPKzEaelI=
-k8s.io/utils v0.0.0-20220922133306-665eaaec4324/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+k8s.io/utils v0.0.0-20221012122500-cfd413dd9e85 h1:cTdVh7LYu82xeClmfzGtgyspNh6UxpwLWGi8R4sspNo=
+k8s.io/utils v0.0.0-20221012122500-cfd413dd9e85/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/providers/providerfactory.go
+++ b/providers/providerfactory.go
@@ -6,6 +6,7 @@ import (
 	"github.com/devops-kung-fu/bomber/models"
 	"github.com/devops-kung-fu/bomber/providers/ossindex"
 	"github.com/devops-kung-fu/bomber/providers/osv"
+	"github.com/devops-kung-fu/bomber/providers/snyk"
 )
 
 // NewProvider will return a provider interface for the requested vulnerability services
@@ -15,6 +16,8 @@ func NewProvider(name string) (provider models.Provider, err error) {
 		provider = ossindex.Provider{}
 	case "osv":
 		provider = osv.Provider{}
+	case "snyk":
+		provider = snyk.Provider{}
 	default:
 		err = fmt.Errorf("%s is not a valid provider type", name)
 	}

--- a/providers/providerfactory_test.go
+++ b/providers/providerfactory_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/devops-kung-fu/bomber/providers/ossindex"
 	"github.com/devops-kung-fu/bomber/providers/osv"
+	"github.com/devops-kung-fu/bomber/providers/snyk"
 )
 
 func TestNewProvider(t *testing.T) {
@@ -17,6 +18,10 @@ func TestNewProvider(t *testing.T) {
 	provider, err = NewProvider("osv")
 	assert.NoError(t, err)
 	assert.IsType(t, osv.Provider{}, provider)
+
+	provider, err = NewProvider("snyk")
+	assert.NoError(t, err)
+	assert.IsType(t, snyk.Provider{}, provider)
 
 	_, err = NewProvider("test")
 	assert.Error(t, err)

--- a/providers/snyk/client.go
+++ b/providers/snyk/client.go
@@ -1,0 +1,18 @@
+package snyk
+
+import (
+	"fmt"
+
+	"github.com/kirinlabs/HttpRequest"
+
+	"github.com/devops-kung-fu/bomber/models"
+)
+
+const USER_AGENT = "Bomber"
+
+func newClient(c *models.Credentials) *HttpRequest.Request {
+	return HttpRequest.NewRequest().SetHeaders(map[string]string{
+		"Authorization": fmt.Sprintf("token %s", c.Token),
+		"User-Agent":    USER_AGENT,
+	})
+}

--- a/providers/snyk/jsonapi.go
+++ b/providers/snyk/jsonapi.go
@@ -1,0 +1,43 @@
+package snyk
+
+type JsonApi struct {
+	// Version of the JSON API specification this server supports.
+	Version string `json:"version"`
+}
+
+type LinkProperty interface{}
+
+type Links struct {
+	PaginatedLinks
+	Related *LinkProperty `json:"related,omitempty"`
+}
+
+type PaginatedLinks struct {
+	First *LinkProperty `json:"first,omitempty"`
+	Last  *LinkProperty `json:"last,omitempty"`
+	Next  *LinkProperty `json:"next,omitempty"`
+	Prev  *LinkProperty `json:"prev,omitempty"`
+	Self  *LinkProperty `json:"self,omitempty"`
+}
+
+// Free-form object that may contain non-standard information.
+type Meta struct {
+	AdditionalProperties map[string]interface{} `json:"-"`
+}
+
+type PackageMeta struct {
+	// The package’s name
+	Name string `json:"name,omitempty"`
+
+	// A name prefix, such as a maven group id or docker image owner
+	Namespace string `json:"namespace,omitempty"`
+
+	// The package type or protocol
+	Type string `json:"type,omitempty"`
+
+	// The purl of the package
+	Url string `json:"url,omitempty"`
+
+	// The version of the package
+	Version string `json:"version,omitempty"`
+}

--- a/providers/snyk/orgid.go
+++ b/providers/snyk/orgid.go
@@ -1,0 +1,48 @@
+package snyk
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/kirinlabs/HttpRequest"
+)
+
+type selfDocument struct {
+	Data struct {
+		Attributes struct {
+			AvatarUrl         string `json:"avatar_url,omitempty"`
+			DefaultOrgContext string `json:"default_org_context,omitempty"`
+			Name              string `json:"name,omitempty"`
+			Username          string `json:"username,omitempty"`
+		} `json:"attributes,omitempty"`
+		Id   string `json:"id,omitempty"`
+		Type string `json:"type,omitempty"`
+	}
+	Jsonapi JsonApi        `json:"jsonapi,omitempty"`
+	Links   PaginatedLinks `json:"links,omitempty"`
+}
+
+func getOrgID(client *HttpRequest.Request) (orgID string, err error) {
+	res, err := client.Get(SNYK_URL + "/self" + SNYK_API_VERSION)
+	if err != nil {
+		return "", fmt.Errorf("unable to retrieve org ID: %w", err)
+	}
+
+	body, err := res.Body()
+	if err != nil {
+		return "", fmt.Errorf("unable to retrieve org ID: %w", err)
+	}
+
+	if res.StatusCode() != 200 {
+		return "", fmt.Errorf("unable to retrieve org ID (status: %s)", res.Response().Status)
+	}
+
+	var userInfo selfDocument
+	if err = json.Unmarshal(body, &userInfo); err != nil {
+		return "", fmt.Errorf("unable to retrieve org ID (status: %s): %w", res.Response().Status, err)
+	}
+
+	orgID = userInfo.Data.Attributes.DefaultOrgContext
+
+	return
+}

--- a/providers/snyk/orgid_test.go
+++ b/providers/snyk/orgid_test.go
@@ -1,0 +1,51 @@
+package snyk
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/devops-kung-fu/bomber/models"
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetOrgID(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder(http.MethodGet, `=~\/self`, httpmock.NewBytesResponder(200, selfResponse))
+
+	client := newClient(&models.Credentials{})
+	orgID, err := getOrgID(client)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "d9546f87-d03d-4dd9-a10e-6ae5fd40d9a1", orgID)
+}
+
+func TestGetOrgIDUnauthorized(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder(http.MethodGet, `=~\/self`, httpmock.NewStringResponder(401, "Unauthorized"))
+
+	client := newClient(&models.Credentials{})
+	orgID, err := getOrgID(client)
+
+	assert.Error(t, err)
+	assert.Equal(t, "unable to retrieve org ID (status: 401)", err.Error())
+	assert.Equal(t, "", orgID)
+}
+
+func TestGetOrgIDInvalidResponse(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder(http.MethodGet, `=~\/self`, httpmock.NewStringResponder(200, "boom"))
+
+	client := newClient(&models.Credentials{})
+	orgID, err := getOrgID(client)
+
+	assert.Error(t, err)
+	assert.Equal(t, "unable to retrieve org ID (status: 200): invalid character 'b' looking for beginning of value", err.Error())
+	assert.Equal(t, "", orgID)
+}

--- a/providers/snyk/snyk.go
+++ b/providers/snyk/snyk.go
@@ -1,0 +1,84 @@
+package snyk
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/remeh/sizedwaitgroup"
+
+	"github.com/devops-kung-fu/bomber/models"
+)
+
+const (
+	SNYK_URL         = "https://api.snyk.io/rest"
+	SNYK_API_VERSION = "?version=2022-09-15~experimental"
+	CONCURRENCY      = 10
+)
+
+type Provider struct{}
+
+// Info provides basic information about the Snyk Provider
+func (Provider) Info() string {
+	return "Snyk (https://security.snyk.io)"
+}
+
+// Scan scans a list of Purls for vulnerabilities against Snyk.
+func (Provider) Scan(purls []string, credentials *models.Credentials) (packages []models.Package, err error) {
+	if err = validateCredentials(credentials); err != nil {
+		return packages, fmt.Errorf("Could not validate credentials: %w", err)
+	}
+
+	wg := sizedwaitgroup.New(CONCURRENCY)
+	client := newClient(credentials)
+	orgID, err := getOrgID(client)
+	if err != nil {
+		return packages, fmt.Errorf("Could not infer user’s Snyk organization: %w", err)
+	}
+
+	for _, pp := range purls {
+		wg.Add()
+
+		go func(purl string) {
+			defer wg.Done()
+
+			vulns, err := getVulnsForPurl(purl, client, orgID)
+			if err != nil {
+				log.Printf("Could not get vulnerabilities for package (%s): %s\n", purl, err.Error())
+			}
+
+			if len(vulns) == 0 {
+				return
+			}
+
+			packages = append(packages, models.Package{
+				Purl:            purl,
+				Vulnerabilities: vulns,
+			})
+		}(pp)
+	}
+
+	wg.Wait()
+	return
+}
+
+func validateCredentials(credentials *models.Credentials) error {
+	if credentials == nil {
+		return errors.New("credentials cannot be nil")
+	}
+
+	if credentials.Token == "" {
+		credentials.Token = os.Getenv("SNYK_TOKEN")
+	}
+
+	if credentials.Token == "" {
+		credentials.Token = os.Getenv("BOMBER_PROVIDER_TOKEN")
+	}
+
+	if credentials.Token == "" {
+		return errors.New("bomber requires a token to use the Snyk provider")
+	}
+
+	return nil
+}

--- a/providers/snyk/snyk_test.go
+++ b/providers/snyk/snyk_test.go
@@ -1,0 +1,88 @@
+package snyk
+
+import (
+	_ "embed"
+	"os"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/devops-kung-fu/bomber/models"
+)
+
+//go:embed testdata/snyk_package_issues_response.json
+var issuesResponse []byte
+
+//go:embed testdata/snyk_self_response.json
+var selfResponse []byte
+
+func TestInfo(t *testing.T) {
+	provider := Provider{}
+	info := provider.Info()
+	assert.Equal(t, "Snyk (https://security.snyk.io)", info)
+}
+
+func Test_validateCredentials(t *testing.T) {
+	// Back up any env tokens
+	bomberToken := os.Getenv("BOMBER_PROVIDER_TOKEN")
+	snykToken := os.Getenv("SNYK_TOKEN")
+
+	os.Unsetenv("BOMBER_PROVIDER_TOKEN")
+	os.Unsetenv("SNYK_TOKEN")
+
+	credentials := models.Credentials{
+		Token: "token",
+	}
+
+	err := validateCredentials(nil)
+	assert.Error(t, err)
+
+	err = validateCredentials(&credentials)
+	assert.NoError(t, err)
+
+	credentials.Token = ""
+	err = validateCredentials(&credentials)
+	assert.Error(t, err)
+
+	os.Setenv("BOMBER_PROVIDER_TOKEN", "bomber-token")
+
+	err = validateCredentials(&credentials)
+	assert.NoError(t, err)
+	assert.Equal(t, "bomber-token", credentials.Token)
+
+	os.Setenv("SNYK_TOKEN", "snyk-token")
+
+	credentials.Token = ""
+	err = validateCredentials(&credentials)
+	assert.NoError(t, err)
+	assert.Equal(t, "snyk-token", credentials.Token)
+
+	//reset env
+	os.Setenv("BOMBER_PROVIDER_TOKEN", bomberToken)
+	os.Setenv("SNYK_TOKEN", snykToken)
+}
+
+func TestProvider_Scan_FakeCredentials(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder("GET", `=~\/self`, httpmock.NewBytesResponder(200, selfResponse))
+	httpmock.RegisterResponder("GET", `=~\/issues`, httpmock.NewBytesResponder(200, issuesResponse))
+
+	credentials := models.Credentials{
+		Token: "token",
+	}
+
+	provider := Provider{}
+	pkgs, err := provider.Scan([]string{"pkg:gem/tzinfo@1.2.5"}, &credentials)
+	assert.NoError(t, err)
+	assert.Len(t, pkgs, 1)
+	pkg := pkgs[0]
+	assert.Equal(t, "pkg:gem/tzinfo@1.2.5", pkg.Purl)
+	assert.Len(t, pkg.Vulnerabilities, 1)
+	httpmock.GetTotalCallCount()
+	calls := httpmock.GetCallCountInfo()
+	assert.Equal(t, 1, calls[`GET =~\/self`])
+	assert.Equal(t, 1, calls[`GET =~\/issues`])
+}

--- a/providers/snyk/testdata/snyk_package_issues_response.json
+++ b/providers/snyk/testdata/snyk_package_issues_response.json
@@ -1,0 +1,98 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "data": [
+    {
+      "id": "SNYK-RUBY-TZINFO-2958048",
+      "type": "issue",
+      "attributes": {
+        "key": "SNYK-RUBY-TZINFO-2958048",
+        "title": "Directory Traversal",
+        "type": "package_vulnerability",
+        "created_at": "2022-07-22T07:23:05.273956Z",
+        "updated_at": "2022-07-24T07:54:55.039170Z",
+        "description": "",
+        "problems": [
+          {
+            "id": "CWE-22",
+            "source": "CWE"
+          },
+          {
+            "id": "GHSA-5cm2-9h8c-rvfx",
+            "source": "GHSA"
+          },
+          {
+            "id": "CVE-2022-31163",
+            "source": "CVE"
+          }
+        ],
+        "coordinates": [
+          {
+            "remedies": [
+              {
+                "type": "indeterminate",
+                "description": "Upgrade the package version to 0.3.61,1.2.10 to fix this vulnerability",
+                "details": {
+                  "upgrade_package": "0.3.61,1.2.10"
+                }
+              }
+            ],
+            "representation": ["<0.3.61", ">=1.0.0, <1.2.10"]
+          }
+        ],
+        "severities": [
+          {
+            "source": "Snyk",
+            "level": "high",
+            "score": 7.5,
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H"
+          },
+          {
+            "source": "SUSE",
+            "level": "high",
+            "score": 7.5,
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H"
+          },
+          {
+            "source": "NVD",
+            "level": "high",
+            "score": 8.1,
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
+          }
+        ],
+        "effective_severity_level": "high",
+        "slots": {
+          "disclosure_time": "2022-07-21T21:39:29Z",
+          "exploit": "Not Defined",
+          "publication_time": "2022-07-22T07:23:05Z",
+          "references": [
+            {
+              "title": "GitHub 0.3.61 Release",
+              "url": "https://github.com/tzinfo/tzinfo/releases/tag/v0.3.61"
+            },
+            {
+              "title": "GitHub 1.2.10 Release",
+              "url": "https://github.com/tzinfo/tzinfo/releases/tag/v1.2.10"
+            },
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/tzinfo/tzinfo/commit/ca29f349856d62cb2b2edb3257d9ddd2f97b3c27"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "links": {
+    "self": ""
+  },
+  "meta": {
+    "package": {
+      "name": "tzinfo",
+      "type": "gem",
+      "url": "pkg:gem/tzinfo@1.2.5",
+      "version": "1.2.5"
+    }
+  }
+}

--- a/providers/snyk/testdata/snyk_self_response.json
+++ b/providers/snyk/testdata/snyk_self_response.json
@@ -1,0 +1,19 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "data": {
+    "type": "user",
+    "id": "3ecd1b48-9055-47fb-b959-a9fdbb3291dc",
+    "attributes": {
+      "name": "jane.doe@example.com",
+      "avatar_url": "",
+      "default_org_context": "d9546f87-d03d-4dd9-a10e-6ae5fd40d9a1",
+      "username": "jane.doe@example.com",
+      "email": "jane.doe@example.com"
+    }
+  },
+  "links": {
+    "self": ""
+  }
+}

--- a/providers/snyk/vulns.go
+++ b/providers/snyk/vulns.go
@@ -1,0 +1,243 @@
+package snyk
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/kirinlabs/HttpRequest"
+	"github.com/package-url/packageurl-go"
+
+	"github.com/devops-kung-fu/bomber/models"
+)
+
+type SnykIssueResource struct {
+	Attributes struct {
+		Coordinates []Coordinate `json:"coordinates,omitempty"`
+		CreatedAt   time.Time    `json:"created_at,omitempty"`
+
+		// A description of the issue in Markdown format
+		Description string `json:"description,omitempty"`
+
+		// The type from enumeration of the issue’s severity level. This is usually set from the issue’s producer, but can be overridden by policies.
+		EffectiveSeverityLevel EffectiveSeverityLevel `json:"effective_severity_level,omitempty"`
+
+		// The Snyk vulnerability ID.
+		Key      string    `json:"key,omitempty"`
+		Problems []Problem `json:"problems,omitempty"`
+
+		// The severity level of the vulnerability: ‘low’, ‘medium’, ‘high’ or ‘critical’.
+		Severities []Severity `json:"severities,omitempty"`
+		Slots      Slots      `json:"slots,omitempty"`
+
+		// A human-readable title for this issue.
+		Title string `json:"title,omitempty"`
+
+		// The issue type
+		Type string `json:"type,omitempty"`
+
+		// When the vulnerability information was last modified.
+		UpdatedAt *string `json:"updated_at,omitempty"`
+	} `json:"attributes,omitempty"`
+
+	// The Snyk ID of the vulnerability.
+	Id string `json:"id,omitempty"`
+
+	// The type of the REST resource. Always ‘issue’.
+	Type string `json:"type,omitempty"`
+}
+
+type Coordinate struct {
+	Remedies []Remedy `json:"remedies,omitempty"`
+
+	// The affected versions of this vulnerability.
+	Representation []string `json:"representation,omitempty"`
+}
+
+type IssuesMeta struct {
+	Package PackageMeta `json:"package,omitempty"`
+}
+
+type Problem struct {
+	// When this problem was disclosed to the public.
+	DisclosedAt time.Time `json:"disclosed_at,omitempty"`
+
+	// When this problem was first discovered.
+	DiscoveredAt time.Time `json:"discovered_at,omitempty"`
+	Id           string    `json:"id"`
+	Source       string    `json:"source"`
+
+	// When this problem was last updated.
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
+
+	// An optional URL for this problem.
+	Url *string `json:"url,omitempty"`
+}
+
+type Remedy struct {
+	// A markdown-formatted optional description of this remedy.
+	Description string `json:"description,omitempty"`
+	Details     struct {
+		// A minimum version to upgrade to in order to remedy the issue.
+		UpgradePackage string `json:"upgrade_package,omitempty"`
+	} `json:"details,omitempty"`
+
+	// The type of the remedy. Always ‘indeterminate’.
+	Type string `json:"type,omitempty"`
+}
+
+type Severity struct {
+	Level string `json:"level,omitempty"`
+
+	// The CVSSv3 value of the vulnerability.
+	Score float64 `json:"score,omitempty"`
+
+	// The source of this severity. The value must be the id of a referenced problem or class, in which case that problem or class is the source of this issue. If source is omitted, this severity is sourced internally in the Snyk application.
+	Source string `json:"source,omitempty"`
+
+	// The CVSSv3 value of the vulnerability.
+	Vector string `json:"vector,omitempty"`
+}
+
+type Slots struct {
+	// The time at which this vulnerability was disclosed.
+	DisclosureTime time.Time `json:"disclosure_time,omitempty"`
+
+	// The exploit maturity. Value of ‘No Data’, ‘Not Defined’, ‘Unproven’, ‘Proof of Concept’, ‘Functional’ or ‘High’.
+	Exploit string `json:"exploit,omitempty"`
+
+	// The time at which this vulnerability was published.
+	PublicationTime string `json:"publication_time,omitempty"`
+	References      []struct {
+		// Descriptor for an external reference to the issue
+		Title string `json:"title,omitempty"`
+
+		// URL for an external reference to the issue
+		Url string `json:"url,omitempty"`
+	} `json:"references,omitempty"`
+}
+
+const (
+	Critical EffectiveSeverityLevel = "critical"
+	High     EffectiveSeverityLevel = "high"
+	Info     EffectiveSeverityLevel = "info"
+	Low      EffectiveSeverityLevel = "low"
+	Medium   EffectiveSeverityLevel = "medium"
+)
+
+// The type from enumeration of the issue’s severity level. This is usually set from the issue’s producer, but can be overridden by policies.
+type EffectiveSeverityLevel string
+
+type SnykIssuesDocument struct {
+	Data    []SnykIssueResource `json:"data,omitempty"`
+	Jsonapi JsonApi             `json:"jsonapi,omitempty"`
+	Links   *PaginatedLinks     `json:"links,omitempty"`
+	Meta    *IssuesMeta         `json:"meta,omitempty"`
+}
+
+func getVulnsForPurl(
+	purl string,
+	client *HttpRequest.Request,
+	orgID string,
+) (vulns []models.Vulnerability, err error) {
+	if err := validatePurl(purl); err != nil {
+		return nil, err
+	}
+
+	issuesURL := fmt.Sprintf(
+		"%s/orgs/%s/packages/%s/issues%s",
+		SNYK_URL, orgID, url.QueryEscape(purl), SNYK_API_VERSION,
+	)
+
+	res, err := client.Get(issuesURL)
+	if err != nil {
+		return nil, fmt.Errorf("could not fetch vulnerabilities (purl: %s): %w", purl, err)
+	}
+	defer res.Close()
+
+	body, err := res.Body()
+	if err != nil {
+		return nil, fmt.Errorf("could not read response body (purl: %s): %w", purl, err)
+	}
+
+	if res.StatusCode() != 200 {
+		return nil, fmt.Errorf("failed request while retrieving vulnerabilities (purl: %s, status: %s)", purl, res.Response().Status)
+	}
+
+	var response SnykIssuesDocument
+	if err = json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("could not parse response (purl: %s): %w", purl, err)
+	}
+
+	for _, v := range response.Data {
+		vuln := snykIssueToBomberVuln(v)
+		vulns = append(vulns, vuln)
+	}
+
+	return vulns, nil
+}
+
+func validatePurl(purl string) error {
+	if _, err := packageurl.FromString(purl); err != nil {
+		return fmt.Errorf("invalid purl: %w", err)
+	}
+	return nil
+}
+
+func snykIssueToBomberVuln(v SnykIssueResource) models.Vulnerability {
+	cvss := getCvss(v)
+	severity := strings.ToUpper(string(v.Attributes.EffectiveSeverityLevel))
+
+	if severity == "MEDIUM" {
+		severity = "MODERATE"
+	}
+
+	return models.Vulnerability{
+		ID:                 v.Id,
+		Title:              v.Attributes.Title,
+		Description:        v.Attributes.Description,
+		Severity:           severity,
+		Cwe:                getCwe(v),
+		CvssScore:          float64(cvss.Score),
+		CvssVector:         cvss.Vector,
+		Reference:          fmt.Sprintf("https://security.snyk.io/vuln/%s", v.Id),
+		ExternalReferences: getExternalReferences(v),
+	}
+}
+
+func getCwe(i SnykIssueResource) string {
+	for _, p := range i.Attributes.Problems {
+		if p.Source == "CWE" {
+			return p.Id
+		}
+	}
+	return ""
+}
+
+func getCvss(i SnykIssueResource) *Severity {
+	var nvdSeverity *Severity
+	for _, ss := range i.Attributes.Severities {
+		switch ss.Source {
+		case "Snyk":
+			return &ss
+		case "NVD":
+			nvdSeverity = &ss
+		}
+	}
+	if nvdSeverity != nil {
+		return nvdSeverity
+	}
+	if len(i.Attributes.Severities) > 0 {
+		return &i.Attributes.Severities[0]
+	}
+	return &Severity{}
+}
+
+func getExternalReferences(i SnykIssueResource) (refs []interface{}) {
+	for _, r := range i.Attributes.Slots.References {
+		refs = append(refs, r.Url)
+	}
+	return refs
+}

--- a/providers/snyk/vulns_test.go
+++ b/providers/snyk/vulns_test.go
@@ -1,0 +1,204 @@
+package snyk
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/devops-kung-fu/bomber/models"
+)
+
+const orgID string = "33e75b5e-3ebe-4d2e-8eba-17a24d20fc72"
+
+func TestGetVulnsForPurlSuccess(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder("GET", `=~\/issues\?version=`, httpmock.NewBytesResponder(200, issuesResponse))
+
+	expected := []models.Vulnerability{
+		{
+			ID:         "SNYK-RUBY-TZINFO-2958048",
+			Title:      "Directory Traversal",
+			Severity:   "HIGH",
+			CvssScore:  float64(7.5),
+			CvssVector: "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H",
+			Cwe:        "CWE-22",
+			Reference:  "https://security.snyk.io/vuln/SNYK-RUBY-TZINFO-2958048",
+			ExternalReferences: []interface{}{
+				"https://github.com/tzinfo/tzinfo/releases/tag/v0.3.61",
+				"https://github.com/tzinfo/tzinfo/releases/tag/v1.2.10",
+				"https://github.com/tzinfo/tzinfo/commit/ca29f349856d62cb2b2edb3257d9ddd2f97b3c27",
+			},
+		},
+	}
+
+	vulns, err := getVulnsForPurl("pkg:gem/tzinfo@1.2.5", newClient(&models.Credentials{}), orgID)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expected, vulns)
+}
+
+func TestGetVulnsForPurlTimeout(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder("GET", `=~\/issues\?version=`, httpmock.NewStringResponder(503, "Gateway Timeout"))
+
+	vulns, err := getVulnsForPurl("pkg:gem/tzinfo@1.2.5", newClient(&models.Credentials{}), orgID)
+
+	assert.Error(t, err)
+	assert.Equal(t, "failed request while retrieving vulnerabilities (purl: pkg:gem/tzinfo@1.2.5, status: 503)", err.Error())
+	assert.Nil(t, vulns)
+}
+
+func TestGetVulnsForPurlInvalidResponse(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder("GET", `=~\/issues\?version=`, httpmock.NewStringResponder(200, "BOOM"))
+
+	vulns, err := getVulnsForPurl("pkg:gem/tzinfo@1.2.5", newClient(&models.Credentials{}), orgID)
+
+	assert.Error(t, err)
+	assert.Equal(t, "could not parse response (purl: pkg:gem/tzinfo@1.2.5): invalid character 'B' looking for beginning of value", err.Error())
+	assert.Nil(t, vulns)
+}
+
+func TestGetVulnsForPurlInvalidPurl(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	vulns, err := getVulnsForPurl("foobar", newClient(&models.Credentials{}), orgID)
+
+	assert.Error(t, err)
+	assert.Equal(t, "invalid purl: scheme is missing", err.Error())
+	assert.Nil(t, vulns)
+}
+
+func TestSnykIssueToBomberVuln(t *testing.T) {
+	issue, err := snykIssueMock()
+	assert.NoError(t, err)
+	vuln := snykIssueToBomberVuln(issue)
+	expected := models.Vulnerability{
+		ID:          "SNYK-RUBY-TZINFO-2958048",
+		Title:       "Directory Traversal",
+		Description: "",
+		Severity:    "HIGH",
+		Cwe:         "CWE-22",
+		CvssScore:   7.5,
+		CvssVector:  "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H",
+		Reference:   "https://security.snyk.io/vuln/SNYK-RUBY-TZINFO-2958048",
+		ExternalReferences: []interface{}{
+			"https://github.com/tzinfo/tzinfo/releases/tag/v0.3.61",
+			"https://github.com/tzinfo/tzinfo/releases/tag/v1.2.10",
+			"https://github.com/tzinfo/tzinfo/commit/ca29f349856d62cb2b2edb3257d9ddd2f97b3c27",
+		},
+	}
+
+	assert.Equal(t, expected, vuln)
+}
+
+func TestSnykIssueToBomberVulnModerate(t *testing.T) {
+	issue, err := snykIssueMock()
+	assert.NoError(t, err)
+	issue.Attributes.EffectiveSeverityLevel = "medium"
+
+	vuln := snykIssueToBomberVuln(issue)
+
+	assert.Equal(t, "MODERATE", vuln.Severity)
+}
+
+func TestSnykIssueToBomberVulnMissingCwe(t *testing.T) {
+	issue, err := snykIssueMock()
+	assert.NoError(t, err)
+	issue.Attributes.Problems = []Problem{}
+
+	vuln := snykIssueToBomberVuln(issue)
+
+	assert.Equal(t, "", vuln.Cwe)
+}
+
+func TestSnykIssueToBomberVulnSnykSeverity(t *testing.T) {
+	tc := []struct {
+		Title             string
+		Severities        []Severity
+		ExpectedCvssScore float64
+	}{
+		{
+			"prefer Snyk score",
+			[]Severity{
+				{Source: "SUSE", Score: 7},
+				{Source: "Snyk", Score: 8},
+				{Source: "NVD", Score: 9},
+			},
+			float64(8),
+		},
+		{
+			"prefer NVD score",
+			[]Severity{
+				{Source: "SUSE", Score: 7},
+				{Source: "NVD", Score: 9},
+			},
+			float64(9),
+		},
+		{
+			"fallback on other",
+			[]Severity{
+				{Source: "SUSE", Score: 7},
+			},
+			float64(7),
+		},
+		{
+			"empty severities", // edge case, should not happen
+			[]Severity{},
+			float64(0),
+		},
+	}
+	issue, err := snykIssueMock()
+	assert.NoError(t, err)
+
+	for _, tt := range tc {
+		t.Run(tt.Title, func(t *testing.T) {
+			issue.Attributes.Severities = tt.Severities
+			vuln := snykIssueToBomberVuln(issue)
+			assert.Equal(t, tt.ExpectedCvssScore, vuln.CvssScore)
+		})
+	}
+}
+
+func TestSnykIssueToBomberVulnOtherSeverity(t *testing.T) {
+	issue, err := snykIssueMock()
+	assert.NoError(t, err)
+	issue.Attributes.Severities = []Severity{
+		{Source: "SUSE", Score: 7},
+	}
+
+	vuln := snykIssueToBomberVuln(issue)
+
+	assert.Equal(t, float64(7), vuln.CvssScore)
+}
+
+func TestValidatePurl(t *testing.T) {
+	t.Run("should raise error for invalid purl", func(t *testing.T) {
+		err := validatePurl("foobar")
+
+		assert.Equal(t, "invalid purl: scheme is missing", err.Error())
+	})
+
+	t.Run("should not raise error for valid purl", func(t *testing.T) {
+		err := validatePurl("pkg:gem/tzinfo@1.2.5")
+
+		assert.NoError(t, err)
+	})
+}
+
+func snykIssueMock() (issue SnykIssueResource, err error) {
+	var doc SnykIssuesDocument
+	if err := json.Unmarshal(issuesResponse, &doc); err != nil {
+		return issue, err
+	}
+	return doc.Data[0], nil
+}


### PR DESCRIPTION
This adds `snyk` as a provider type to `bomber scan`. It will fetch vulnerability information from the [Snyk VulnerabilityDB](https://security.snyk.io/). It requires a Snyk API token, so will only be available to Snyk customers.

#### Example usage

```sh
$ SNYK_TOKEN=<snyk_api_token> ./bomber scan --provider=snyk sbom/test/railsgoat.cyclonedx.json
```

Authored by @garethr and @mcombuechen.