### PR TITLE
chore: make purls unique in Snyk provider

### DIFF
--- a/providers/snyk/snyk.go
+++ b/providers/snyk/snyk.go
@@ -37,7 +37,7 @@ func (Provider) Scan(purls []string, credentials *models.Credentials) (packages 
 		return packages, fmt.Errorf("Could not infer user’s Snyk organization: %w", err)
 	}
 
-	for _, pp := range purls {
+	for _, pp := range uniq(purls) {
 		wg.Add()
 
 		go func(purl string) {
@@ -81,4 +81,20 @@ func validateCredentials(credentials *models.Credentials) error {
 	}
 
 	return nil
+}
+
+func uniq(strings []string) []string {
+	if len(strings) < 2 {
+		return strings
+	}
+	seen := map[string]bool{}
+	unique := []string{}
+	for _, s := range strings {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = true
+		unique = append(unique, s)
+	}
+	return unique
 }


### PR DESCRIPTION
We'd like to optimize the number of API calls and prevent unnecessary requests. This removes possible duplicates in the list of received purls in the Snyk provider, before fetching vulnerabilities from Snyk.