### PR TITLE
chore: update snyk readme to include more ecosystems support

### DIFF
--- a/doc/providers/snyk.md
+++ b/doc/providers/snyk.md
@@ -30,3 +30,5 @@ At this time, the Snyk provider supports the following ecosystems:
 * PyPi
 * Hex
 * Cargo
+* Swift
+* C/C++


### PR DESCRIPTION
Snyk also supports Swift and C/C++. This PR makes a minor edit to the readme to include those ecosystems.