### PR TITLE
Update Snyk docs

### DIFF
--- a/doc/providers/snyk.md
+++ b/doc/providers/snyk.md
@@ -32,3 +32,7 @@ At this time, the Snyk provider supports the following ecosystems:
 * Cargo
 * Swift
 * C/C++
+* apk
+* Debian
+* Docker
+* RPM


### PR DESCRIPTION
This adds newly supported purl types apk, deb, docker and rpm to the documentation for the Snyk provider.