### PR TITLE
correct Loader object shadowing to correct SEGFAULT

### DIFF
--- a/lib/scanner.go
+++ b/lib/scanner.go
@@ -37,7 +37,7 @@ var loader Loader
 
 // Scan performs the vulnerability scan.
 func (s *Scanner) Scan(args []string) (exitCode int, err error) {
-	loader := Loader{
+	loader = Loader{
 		s.Afs,
 	}
 	// Load packages and associated data


### PR DESCRIPTION
This addresses issue #204. I traced the issue to https://github.com/devops-kung-fu/bomber/blob/79b5dc75344e146541776b3ab80c2913b75115ec/lib/loader.go#L151 where a SEGFAULT occurs due to `l.Afs == null`.