### PR TITLE
Clone transport

### DIFF
--- a/enrichers/epss/epss.go
+++ b/enrichers/epss/epss.go
@@ -25,8 +25,10 @@ type Enricher struct{}
 var client *resty.Client
 
 func init() {
-	client = resty.New().
-		SetTransport(&http.Transport{TLSHandshakeTimeout: 60 * time.Second})
+	// Cloning the transport ensures a proper working http client that respects the proxy settings
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSHandshakeTimeout = 60 * time.Second
+	client = resty.New().SetTransport(transport)
 }
 
 // TODO: this needs to be refactored so we can batch the scanning and de-duplicate. Each component has it's own list of []models.Vulnerability and this function is called multiple times. At least the implementation here reduces the calls by batching per component.

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
-	github.com/sashabaranov/go-openai v1.28.1
+	github.com/sashabaranov/go-openai v1.28.2
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/net v0.28.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/sashabaranov/go-openai v1.28.1 h1:aREx6faUTeOZNMDTNGAY8B9vNmmN7qoGvDV0Ke2J1Mc=
-github.com/sashabaranov/go-openai v1.28.1/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
+github.com/sashabaranov/go-openai v1.28.2 h1:Q3pi34SuNYNN7YrqpHlHbpeYlf75ljgHOAVM/r1yun0=
+github.com/sashabaranov/go-openai v1.28.2/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=
 github.com/spf13/afero v1.11.0/go.mod h1:GH9Y3pIexgf1MTIWtNGyogA5MwRIDXGUr+hbWNoBjkY=
 github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=

--- a/providers/ossindex/OSSIndex.go
+++ b/providers/ossindex/OSSIndex.go
@@ -21,8 +21,10 @@ const ossindexURL = "https://ossindex.sonatype.org/api/v3/authorized/component-r
 var client *resty.Client
 
 func init() {
-	client = resty.New().
-		SetTransport(&http.Transport{TLSHandshakeTimeout: 60 * time.Second})
+	// Cloning the transport ensures a proper working http client that respects the proxy settings
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSHandshakeTimeout = 60 * time.Second
+	client = resty.New().SetTransport(transport)
 }
 
 // Provider represents the OSSIndex provider

--- a/providers/osv/osv.go
+++ b/providers/osv/osv.go
@@ -94,8 +94,10 @@ const (
 var client *resty.Client
 
 func init() {
-	client = resty.New().
-		SetTransport(&http.Transport{TLSHandshakeTimeout: 60 * time.Second})
+	// Cloning the transport ensures a proper working http client that respects the proxy settings
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSHandshakeTimeout = 60 * time.Second
+	client = resty.New().SetTransport(transport)
 }
 
 // Provider represents the OSSIndex provider


### PR DESCRIPTION
The current version of bomber does not work in environments that require a proxy to access the internet. 
Instead of using a bare http.Transport with the modified tls timeout, I use a clone http.DefaultTransport with the modified TLSHandshakeTimeout.

```
func init() {
	// Cloning the transport ensures a proper working http client that respects the proxy settings
	transport := http.DefaultTransport.(*http.Transport).Clone()
	transport.TLSHandshakeTimeout = 60 * time.Second
	client = resty.New().SetTransport(transport)
}
```
