### PR TITLE
feat: add support for alternative Snyk API URLs

### DIFF
--- a/doc/providers/snyk.md
+++ b/doc/providers/snyk.md
@@ -16,6 +16,12 @@ bomber scan --provider snyk --token xxx sbom.json
 
 Note rather than passing the API token explicitly, you can also set this as an environment variable, either as `SNYK_TOKEN` or the generic `BOMBER_PROVIDER_TOKEN`.
 
+By default, `bomber` will use Snyk's global API (https://api.snyk.io). To use a different Snyk API, you can specify its base URL on the `SNYK_API` environment variable.
+
+```
+SNYK_API=https://api.eu.snyk.io bomber scan --provider snyk sbom.json
+```
+
 
 ## Supported ecosystems
 

--- a/providers/snyk/orgid.go
+++ b/providers/snyk/orgid.go
@@ -25,14 +25,13 @@ type selfDocument struct {
 }
 
 func getOrgID(token string) (orgID string, err error) {
-
 	client := resty.New()
 	client.Debug = true
 
 	resp, err := client.R().
 		SetHeader("User-Agent", "bomber").
 		SetAuthToken(token).
-		Get(SnykURL + "/self" + SnykAPIVersion)
+		Get(getSnykAPIURL() + "/rest/self" + SnykAPIVersion)
 
 	if err != nil {
 		log.Print(err)

--- a/providers/snyk/snyk.go
+++ b/providers/snyk/snyk.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	SnykURL        = "https://api.snyk.io/rest"
+	SnykURL        = "https://api.snyk.io"
 	SnykAPIVersion = "?version=2022-09-15~experimental"
 	Concurrency    = 10
 )
@@ -101,4 +101,12 @@ func validateCredentials(credentials *models.Credentials) error {
 	}
 
 	return nil
+}
+
+func getSnykAPIURL() string {
+	u := os.Getenv("SNYK_API")
+	if u != "" {
+		return u
+	}
+	return SnykURL
 }

--- a/providers/snyk/snyk_test.go
+++ b/providers/snyk/snyk_test.go
@@ -62,6 +62,16 @@ func Test_validateCredentials(t *testing.T) {
 	os.Setenv("SNYK_TOKEN", snykToken)
 }
 
+func Test_getSnykAPIURL_default(t *testing.T) {
+	assert.Equal(t, "https://api.snyk.io", getSnykAPIURL())
+}
+
+func Test_getSnykAPIURL_override(t *testing.T) {
+	os.Setenv("SNYK_API", "http://example.com")
+	defer os.Unsetenv("SNYK_API")
+	assert.Equal(t, "http://example.com", getSnykAPIURL())
+}
+
 // func TestProvider_Scan_FakeCredentials(t *testing.T) {
 // 	httpmock.Activate()
 // 	defer httpmock.DeactivateAndReset()

--- a/providers/snyk/vulns.go
+++ b/providers/snyk/vulns.go
@@ -150,8 +150,8 @@ func getVulnsForPurl(
 	}
 
 	issuesURL := fmt.Sprintf(
-		"%s/orgs/%s/packages/%s/issues%s",
-		SnykURL, orgID, url.QueryEscape(purl), SnykAPIVersion,
+		"%s/rest/orgs/%s/packages/%s/issues%s",
+		getSnykAPIURL(), orgID, url.QueryEscape(purl), SnykAPIVersion,
 	)
 
 	client := resty.New()


### PR DESCRIPTION
Hey @djschleen 

we've had a few customers who requested we bring in a new feature where you can specify a Snyk API other than https://api.snyk.io. This is especially attractive to our customer base in the EU and Australia (but not exclusively) where there are local APIs, e.g. https://api.eu.snyk.io.

Let me know if you think this is a good addition. Cheers!