### PR TITLE
fix: snyk API auth header

### DIFF
--- a/providers/snyk/orgid.go
+++ b/providers/snyk/orgid.go
@@ -30,6 +30,7 @@ func getOrgID(token string) (orgID string, err error) {
 
 	resp, err := client.R().
 		SetHeader("User-Agent", "bomber").
+		SetAuthScheme("token").
 		SetAuthToken(token).
 		Get(getSnykAPIURL() + "/rest/self" + SnykAPIVersion)
 

--- a/providers/snyk/snyk.go
+++ b/providers/snyk/snyk.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	SnykURL        = "https://api.snyk.io"
-	SnykAPIVersion = "?version=2022-09-15~experimental"
+	SnykAPIVersion = "?version=2024-10-15"
 	Concurrency    = 10
 )
 

--- a/providers/snyk/vulns.go
+++ b/providers/snyk/vulns.go
@@ -159,6 +159,7 @@ func getVulnsForPurl(
 
 	resp, err := client.R().
 		SetHeader("User-Agent", "bomber").
+		SetAuthScheme("token").
 		SetAuthToken(token).
 		Get(issuesURL)
 


### PR DESCRIPTION
Snyk requires auth schema of "token" rather than the default "Bearer". See https://docs.snyk.io/snyk-api/authentication-for-api

It is possible to connect using a Bearer token via Snyk Apps but for the average user it's much easier to authenticate using a personal API token, as decribed in the provider readme doc/providers/snyk.md.

Moving to the latest Snyk API version `2024-10-15`. The endpoints used by bomber haven't changed spec. The request and response schemas for `/self` and `/issues` remain the same.